### PR TITLE
Use test configuration for URL tracking parameter protection tests (#1987)

### DIFF
--- a/integration-test/url-parameters.spec.js
+++ b/integration-test/url-parameters.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from './helpers/playwrightHarness'
 import backgroundWait from './helpers/backgroundWait'
 import { routeFromLocalhost } from './helpers/testPages'
+import { loadTestConfig } from './helpers/testConfig'
 
 const testSite = 'https://privacy-test-pages.glitch.me/privacy-protections/query-parameters/'
 
@@ -35,6 +36,7 @@ test.describe('Test URL tracking parameters protection', () => {
     test('Strips tracking parameters correctly', async ({ context, backgroundPage, page, manifestVersion }) => {
         await backgroundWait.forExtensionLoaded(context)
         await backgroundWait.forAllConfiguration(backgroundPage)
+        await loadTestConfig(backgroundPage, 'url-parameters.json')
         await routeFromLocalhost(page)
 
         await page.goto(testSite, { waitUntil: 'networkidle' })


### PR DESCRIPTION
The URL tracking parameter protection tests should make use of the test url-parameters.json configuration. It seems that got missed when we ported the test to Playwright. Let's fix that here, to get those tests passing more reliably again.

<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->


## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
